### PR TITLE
Integrated Ollama nomic-embed-text (768-dim) model with pgvector backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ flake8==7.1.0
 fpdf==1.7.2
 h11==0.16.0
 httpcore==1.0.9
-httpx==0.28.1
+httpx==0.27.2
 idna==3.11
 iniconfig==2.3.0
 numpy>=2.1.2
@@ -48,6 +48,4 @@ psycopg2-binary==2.9.10
 pgvector==0.3.2
 
 # Embeddings
-sentence-transformers==3.3.1
-torch>=2.5.1
-einops
+ollama==0.3.2

--- a/src/backend/database_vector.py
+++ b/src/backend/database_vector.py
@@ -35,7 +35,7 @@ class DocumentChunk(Base):
     id = Column(Integer, primary_key=True)
     document_id = Column(Integer, ForeignKey("documents.id"))
     chunk_text = Column(String)
-    embedding = Column(Vector(1024))  # Cohere embed-v3 = 1024 dims
+    embedding = Column(Vector(768))  # nomic-embed-text:latest 
     document = relationship("Document", back_populates="chunks")
 
 

--- a/src/tests/backend_test/test_vector_service.py
+++ b/src/tests/backend_test/test_vector_service.py
@@ -70,7 +70,7 @@ def test_store_empty_text():
     assert len(doc.chunks) == 0
 
 def test_embedding_vector_dimension(tmp_path):
-    """Checks that embeddings are 1024-dimensional."""
+    """Checks that embeddings are 768-dimensional."""
     sample_file = tmp_path / "embed_test.txt"
     sample_file.write_text("The quick brown fox jumps over the lazy dog.")
     content = sample_file.read_text()
@@ -83,7 +83,7 @@ def test_embedding_vector_dimension(tmp_path):
     db.close()
 
     assert chunk is not None, "No chunk found for embed_test.txt"
-    assert len(chunk.embedding) == 1024, f"Expected 1024-dim vector, got {len(chunk.embedding)}"
+    assert len(chunk.embedding) == 768, f"Expected 768-dim vector, got {len(chunk.embedding)}"
 
 def test_embedding_consistency(tmp_path):
     """Ensures same input text produces identical embeddings."""


### PR DESCRIPTION
## 📝 Description

This PR implements the vector embedding integration for the backend, enabling automatic text embedding and storage in the pgvector database. The system now uses the local Ollama model `nomic-embed-text:latest` (instead of the cloud-based JinaAI model) to generate 768-dimensional embeddings for document chunks.


- [x] Added logic in `vector_service.py` to Generate embeddings per chunk  
- [x] Replaced JinaAI jina-embeddings-v3 with Ollama nomic-embed-text:latest (768-dim)
- [x] Updated vector_service.py to use the Ollama API for local embeddings
- [x] Added vector column `vector(768)` to `document_chunks` table
- [x] Adjusted test cases (test_vector_service.py) to validate 768-dim vectors
- [x] Confirmed embeddings are stored and retrieved correctly from pgvector



**Closes:** # (https://github.com/COSC-499-W2025/capstone-project-team-6/issues/112)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Automated Testing
Executed tests located at src/tests/backend_test/test_vector_service.py:
```
pytest -v src/tests/backend_test/test_vector_service.py
```

### Manual Testing
1. Run Backend Embedding service
```
cd src
python -m backend.vector_service
```
expected output: 
Stored 1 chunks for test_doc.txt
Inserted test_doc.txt into database.
2. Verify vector storage in pgvector
```
cd scripts
docker exec -it local_pgvector psql -U postgres -d vector_db -c "SELECT vector_dims(embedding) FROM document_chunks LIMIT 1;"
```
expected output:
id  | vector_dims 
-----+-------------
 102 |         768

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="935" height="295" alt="Screenshot 2025-11-08 at 3 21 50 PM" src="https://github.com/user-attachments/assets/a77431da-956b-43c2-9d8c-14a2f401e896" />
<img width="617" height="100" alt="Screenshot 2025-11-08 at 3 38 54 PM" src="https://github.com/user-attachments/assets/a169c706-10c2-46dc-aca6-d50c73f5ad54" />

</details>
