### PR TITLE
Revoke Consent Feature

### DIFF
--- a/src/backend/cli.py
+++ b/src/backend/cli.py
@@ -1004,11 +1004,11 @@ def main() -> int:
                 return 1
 
             # Handle consent for first-time users
-            # if not handle_first_time_consent(args.username):
-            #    # User is authenticated but denied consent
-            #    print("\nDenied Consent.")
-            #    print("You can update your consent later using 'mda consent --update'")
-            #    return 1
+            if not handle_first_time_consent(args.username):
+                # User is authenticated but denied consent
+                print("\nDenied Consent.")
+                print("You can update your consent later using 'mda consent --update'")
+                return 1
 
             # Save session for future commands
             save_session(args.username)
@@ -1038,13 +1038,19 @@ def main() -> int:
                 return 0
 
             if args.update:
+                print("\nConsent Update")
+                print("------------------")
+
                 if has_consented:
-                    print("\nYou have already provided consent.")
-                    print("To revoke consent, contact support.")
+                    choice = input("You have already provided consent. Do you want to revoke consent? (y/n): ").strip().lower()
+                    if choice in ("y", "yes"):
+                        save_user_consent(username, False)
+                        print("\nConsent revoked. AI-powered features have been disabled.")
+                    else:
+                        print("\nConsent remains active. No changes made.")
                     return 0
 
-                print("\nConsent Required")
-                print("------------------")
+                print("Consent Required")
                 if ask_for_consent():
                     save_user_consent(username, True)
                     print("\nThank you for providing consent!")
@@ -1061,12 +1067,12 @@ def main() -> int:
                 return 1
 
             username = session["username"]
-            # if not check_user_consent(username):
-            #    print("\nPlease provide consent before analyzing files")
-            #    print("Run 'mda consent --update' to view and accept the consent form")
-            #    return 1
-
             has_consented = check_user_consent(username)
+
+            if not has_consented:
+                print("\nPlease provide consent before analyzing files")
+                print("Run 'mda consent --update' to view and accept the consent form")
+                return 1
 
             llm_features_requested = (
                 args.all or args.prompt or args.architecture or args.security or args.skills or args.domain or args.resume
@@ -1359,7 +1365,10 @@ def main() -> int:
 
                 # Prompt to save JSON output
                 print("\n" + "=" * 70)
-                response = input("Would you like to save the full analysis as JSON? (y/N): ").strip().lower()
+                try:
+                    response = input("Would you like to save the full analysis as JSON? (y/N): ").strip().lower()
+                except (EOFError, OSError):
+                    response = "n"
                 if response in ["y", "yes"]:
                     import json
                     from datetime import datetime

--- a/src/tests/integration_test/test_cli_integration.py
+++ b/src/tests/integration_test/test_cli_integration.py
@@ -217,12 +217,34 @@ class TestCLIConsentCommands:
 
         session.save_session("testuser")
 
-        with patch("sys.argv", ["cli", "consent", "--update"]), patch("sys.stdout", new=StringIO()) as fake_out:
+        with patch("sys.argv", ["cli", "consent", "--update"]), patch.object(builtins, "input", return_value="n"), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_out:
             result = main()
             output = fake_out.getvalue()
 
             assert result == 0
-            assert "You have already provided consent" in output
+            assert "Consent remains active" in output
+            assert database.check_user_consent("testuser") is True
+
+    def test_consent_revocation_for_consented_user(self, isolated_test_env, temp_session_file):
+        """Test revoking consent for user who already consented."""
+        database.create_user("testuser", "password123")
+        database.save_user_consent("testuser", True)
+
+        from backend import session
+
+        session.save_session("testuser")
+
+        with patch("sys.argv", ["cli", "consent", "--update"]), patch.object(builtins, "input", return_value="y"), patch(
+            "sys.stdout", new=StringIO()
+        ) as fake_out:
+            result = main()
+            output = fake_out.getvalue()
+
+            assert result == 0
+            assert "Consent revoked" in output
+            assert database.check_user_consent("testuser") is False
 
     def test_consent_commands_require_login(self, isolated_test_env):
         """Test that consent commands require being logged in."""
@@ -295,8 +317,8 @@ class TestCLIAnalyzeFlow:
             output = fake_out.getvalue()
 
             assert result == 0
-            assert "Analyzing folder" in output
-            assert "Analysis Results" in output
+            assert "[*] Analyzing" in output
+            assert "Analysis complete" in output
 
 
 class TestCLIEndToEndWorkflow:
@@ -327,7 +349,8 @@ class TestCLIEndToEndWorkflow:
         with patch("sys.argv", ["cli", "analyze", str(test_directory)]), patch("sys.stdout", new=StringIO()) as fake_out:
             result = main()
             assert result == 0
-            assert "Analysis Results" in fake_out.getvalue()
+            assert "[*] Analyzing" in fake_out.getvalue()
+            assert "Analysis complete" in fake_out.getvalue()
 
     def test_workflow_with_consent_denial_then_update(self, isolated_test_env, temp_session_file, test_directory):
         """Test workflow: signup (deny consent) -> login -> consent update -> analyze."""
@@ -366,7 +389,8 @@ class TestCLIEndToEndWorkflow:
         with patch("sys.argv", ["cli", "analyze", str(test_directory)]), patch("sys.stdout", new=StringIO()) as fake_out:
             result = main()
             assert result == 0
-            assert "Analysis Results" in fake_out.getvalue()
+            assert "[*] Analyzing" in fake_out.getvalue()
+            assert "Analysis complete" in fake_out.getvalue()
 
     def test_workflow_signup_first_time_login_with_consent(self, isolated_test_env, temp_session_file):
         """Test workflow: signup (no consent prompt) -> first-time login (consent prompt)."""


### PR DESCRIPTION
## 📝 Description

- Add built-in consent revocation flow in `mda consent --update` and persist revoked state to disable AI features.
- Reinstate first-time login consent check; deny login when consent is refused.
- Enforce consent requirement before running `analyze` and harden JSON save prompt against stdin capture errors.
- Update integration tests to cover consent revocation and align analyze output assertions.
- Closes: #314

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- `python -m pytest src/tests/integration_test/test_cli_integration.py`  All 22 tests should pass

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<img width="1370" height="128" alt="Screenshot 2026-01-25 at 3 09 41 PM" src="https://github.com/user-attachments/assets/e6035719-c5d1-496e-99e4-fce246e3354c" />


</details>