### PR TITLE
Fix consent form bug 

### DIFF
--- a/src/backend/cli.py
+++ b/src/backend/cli.py
@@ -1101,14 +1101,14 @@ def main() -> int:
             username = session["username"]
             has_consented = check_user_consent(username)
 
-            if not has_consented:
-                print("\nPlease provide consent before analyzing files")
-                print("Run 'mda consent --update' to view and accept the consent form")
-                return 1
-
             llm_features_requested = (
                 args.all or args.prompt or args.architecture or args.security or args.skills or args.domain or args.resume
             )
+
+            if not has_consented and llm_features_requested:
+                print("\nPlease provide consent before using AI-powered analysis features")
+                print("Run 'mda consent --update' to view and accept the consent form")
+                return 1
 
             path = Path(args.path)
             if not path.exists():


### PR DESCRIPTION
## 📝 Description

A previous PR introduced a bug where all analysis was blocked if the user hadn't provided consent, even for basic non-AI analysis. This broke the intended behaviour where users could still run standard analysis without consent. Previously The consent check was placed before checking if AI features were requested. 

Now, the check was moved before consent validation and it is conditional. 

**Closes:** #315 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Run the entire analysis pipeline and revoke consent to see if the analysis is stored in the database. It should be stored. 

---

## ✓ Checklist

- [ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
