### PR TITLE
Extended tests for portfolio items rendering

### DIFF
--- a/src/frontend/src/tests/pages/Portfolio.test.jsx
+++ b/src/frontend/src/tests/pages/Portfolio.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
@@ -51,6 +51,7 @@ const mockPortfolioList = [
     analysis_timestamp: '2026-01-01T08:00:00Z',
     total_projects: 2,
     analysis_type: 'llm',
+    project_names: ['Alpha'],
   },
   {
     analysis_uuid: 'run-2',
@@ -58,6 +59,7 @@ const mockPortfolioList = [
     analysis_timestamp: '2026-02-02T11:30:00Z',
     total_projects: 1,
     analysis_type: 'non_llm',
+    project_names: ['Beta'],
   },
 ];
 
@@ -160,19 +162,64 @@ describe('Portfolio page', () => {
     });
   });
 
-  it('displays summary, skills, and projects once data is available', async () => {
+  it('displays skills and projects once data is available', async () => {
     portfoliosAPI.listPortfolios.mockResolvedValue(mockPortfolioList);
     portfoliosAPI.getPortfolioDetail.mockResolvedValue(mockDetailFirst);
 
     renderWithAuth();
 
     await waitFor(() => {
-      expect(screen.getByText('Summary of run 1')).toBeInTheDocument();
       expect(screen.getByText('Python')).toBeInTheDocument();
-      expect(screen.getByText('Alpha')).toBeInTheDocument();
+      expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
       expect(screen.getByText('Alpha highlight')).toBeInTheDocument();
       expect(screen.getByText(/Quality score: 45/)).toBeInTheDocument();
       expect(screen.getByText(/Sophistication: intermediate/)).toBeInTheDocument();
+    });
+  });
+
+  it('does not render the summary section', async () => {
+    portfoliosAPI.listPortfolios.mockResolvedValue(mockPortfolioList);
+    portfoliosAPI.getPortfolioDetail.mockResolvedValue(mockDetailFirst);
+
+    renderWithAuth();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Summary')).not.toBeInTheDocument();
+      expect(screen.queryByText('Summary of run 1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('derives highlighted skills from portfolio items when skills list is empty', async () => {
+    portfoliosAPI.listPortfolios.mockResolvedValue(mockPortfolioList);
+    portfoliosAPI.getPortfolioDetail.mockResolvedValue({
+      ...mockDetailFirst,
+      skills: [],
+      portfolio_items: [
+        {
+          project_name: 'Alpha',
+          text_summary: 'Skill fallback test',
+          skills_exercised: ['Backend APIs', 'Testing', 'Backend APIs'],
+        },
+      ],
+    });
+
+    renderWithAuth();
+
+    await waitFor(() => {
+      expect(screen.getByText('Backend APIs')).toBeInTheDocument();
+      expect(screen.getByText('Testing')).toBeInTheDocument();
+    });
+  });
+
+  it('shows project names in available analyses cards', async () => {
+    portfoliosAPI.listPortfolios.mockResolvedValue(mockPortfolioList);
+    portfoliosAPI.getPortfolioDetail.mockResolvedValue(mockDetailFirst);
+
+    renderWithAuth();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+      expect(screen.getByText('Beta')).toBeInTheDocument();
     });
   });
 
@@ -185,18 +232,51 @@ describe('Portfolio page', () => {
     renderWithAuth();
 
     await waitFor(() => {
-      expect(screen.getByText('Summary of run 1')).toBeInTheDocument();
+      expect(screen.getByText('Alpha highlight')).toBeInTheDocument();
     });
 
     const secondCard = screen.getByTestId('portfolio-card-run-2');
-    secondCard.click();
+    fireEvent.click(secondCard);
 
     await waitFor(() => {
-      expect(screen.getByText('Summary of run 2')).toBeInTheDocument();
+      expect(screen.getByText('A JavaScript project with nested stats output shape.')).toBeInTheDocument();
       expect(screen.getByText(/Quality score: 38/)).toBeInTheDocument();
       expect(screen.getByText(/Sophistication: intermediate/)).toBeInTheDocument();
     });
 
     expect(portfoliosAPI.getPortfolioDetail).toHaveBeenCalledWith('run-2');
+  });
+
+  it('renders portfolio item metadata fields (summary, tech stack, and skills)', async () => {
+    portfoliosAPI.listPortfolios.mockResolvedValue(mockPortfolioList);
+    portfoliosAPI.getPortfolioDetail.mockResolvedValue(mockDetailFirst);
+
+    renderWithAuth();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha highlight')).toBeInTheDocument();
+      expect(
+        screen.getByText('A Python backend project with strong code quality signals.')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Tech stack: Python, FastAPI')).toBeInTheDocument();
+      expect(screen.getByText('Skills: API design, Testing')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no portfolio items are returned', async () => {
+    portfoliosAPI.listPortfolios.mockResolvedValue(mockPortfolioList);
+    portfoliosAPI.getPortfolioDetail.mockResolvedValue({
+      ...mockDetailFirst,
+      portfolio_items: [],
+      items: [],
+    });
+
+    renderWithAuth();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No portfolio items were returned by the backend yet.')
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
# 📝 Description

This PR updates and expands the `Portfolio` page test suite to reflect recent portfolio UI and backend-contract changes, and adds explicit coverage for portfolio item rendering behavior.

### What this fixes
- Prevents regressions where tests still expected removed/old UI behavior (e.g., Summary section).
- Validates current rendering behavior for:
  - portfolio item metadata (title, summary, tech stack, skills),
  - quality/sophistication display (including nested `project_statistics` fallback),
  - derived highlighted skills when `skills` is empty,
  - available analyses card titles from `project_names`,
  - empty-state handling when no portfolio items are returned.

### Motivation / context
The Portfolio page behavior changed significantly, but test coverage was lagging. This PR aligns tests with the current product behavior and improves confidence around core portfolio rendering paths.

### Dependencies
- No new runtime dependencies.
- Uses existing frontend test stack (`vitest`, `@testing-library/react`).

**Closes:** #376

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- Ran targeted Portfolio test suite:
  - `cd src/frontend`
  - `npm run test -- src/tests/pages/Portfolio.test.jsx`
- Result: all tests passed (`10/10`).

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
<details>
<img width="1145" height="486" alt="Screenshot 2026-02-15 at 5 49 09 PM" src="https://github.com/user-attachments/assets/8fa9bc69-f961-4ac1-a6f4-7918faa2daa6" />
</details>