### PR TITLE
Aakash/validate settings

### DIFF
--- a/src/frontend/src/pages/Resume.jsx
+++ b/src/frontend/src/pages/Resume.jsx
@@ -55,8 +55,13 @@ const Resume = () => {
       errs.email = 'Enter a valid email address.';
     }
 
-    if (info.phone.trim() && !/^[+\d][\d\s\-().]{6,20}$/.test(info.phone.trim())) {
-      errs.phone = 'Phone may only contain digits, spaces, dashes, parentheses, or a leading +.';
+    const phoneTrim = info.phone.trim();
+    if (phoneTrim) {
+      if (!/^[+\d][\d\s\-().]{7,20}$/.test(phoneTrim)) {
+        errs.phone = 'Phone may only contain digits, spaces, dashes, parentheses, or a leading +. Minimum of 7 digits required.';
+      } else if ((phoneTrim.replace(/\D/g, '').length || 0) < 7) {
+        errs.phone = 'Phone may only contain digits, spaces, dashes, parentheses, or a leading +. Minimum of 7 digits required.';
+      }
     }
 
     if (info.location.trim().length > 100) {
@@ -283,6 +288,7 @@ const Resume = () => {
   const handleGenerateResume = async () => {
     if (selectedProjectIds.length === 0) {
       setError('Please select at least one project');
+      try { window.scrollTo(0, 0); } catch (_) {}
       return;
     }
 
@@ -290,6 +296,7 @@ const Resume = () => {
     if (Object.keys(errs).length > 0) {
       setPersonalErrors(errs);
       setError('Please fix the personal information errors before generating.');
+      try { window.scrollTo(0, 0); } catch (_) {}
       return;
     }
     setPersonalErrors({});
@@ -315,6 +322,7 @@ const Resume = () => {
     } catch (err) {
       console.error('Error generating resume:', err);
       setError(err.response?.data?.detail || 'Failed to generate resume');
+      try { window.scrollTo(0, 0); } catch (_) {}
     } finally {
       setGenerating(false);
     }
@@ -426,8 +434,49 @@ const Resume = () => {
       style={{
         minHeight: '100vh',
         backgroundColor: '#fafafa',
+        paddingTop: error ? '52px' : 0,
       }}
     >
+      {/* Fixed error toast at top so Generate Resume errors are visible without scrolling */}
+      {error && (
+        <div
+          role="alert"
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: 9999,
+            backgroundColor: '#dc2626',
+            color: 'white',
+            padding: '12px 16px',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '16px',
+          }}
+        >
+          <span style={{ flex: 1 }}>{error}</span>
+          <button
+            type="button"
+            onClick={() => setError('')}
+            aria-label="Dismiss"
+            style={{
+              background: 'rgba(255,255,255,0.2)',
+              border: 'none',
+              color: 'white',
+              padding: '6px 12px',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontWeight: '500',
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
       <Navigation />
 
       <div

--- a/src/frontend/src/pages/Settings.jsx
+++ b/src/frontend/src/pages/Settings.jsx
@@ -88,8 +88,13 @@ const Settings = () => {
       errs.email = 'Enter a valid email address.';
     }
 
-    if (info.phone.trim() && !/^[+\d][\d\s\-().]{6,20}$/.test(info.phone.trim())) {
-      errs.phone = 'Phone may only contain digits, spaces, dashes, parentheses, or a leading +.';
+    const phoneTrim = info.phone.trim();
+    if (phoneTrim) {
+      if (!/^[+\d][\d\s\-().]{7,20}$/.test(phoneTrim)) {
+        errs.phone = 'Phone may only contain digits, spaces, dashes, parentheses, or a leading +. Minimum of 7 digits required.';
+      } else if ((phoneTrim.replace(/\D/g, '').length || 0) < 7) {
+        errs.phone = 'Phone may only contain digits, spaces, dashes, parentheses, or a leading +. Minimum of 7 digits required.';
+      }
     }
 
     if (info.location.trim().length > 100) {

--- a/src/frontend/src/tests/Resume.test.jsx
+++ b/src/frontend/src/tests/Resume.test.jsx
@@ -223,11 +223,9 @@ describe('Resume Page', () => {
       fireEvent.click(checkboxes[0]);
       fireEvent.click(screen.getByRole('button', { name: /generate resume/i }));
 
-      // Error message must appear — not a blank screen
+      // Error message must appear in toast at top — not a blank screen
       await waitFor(() => {
-        expect(
-          screen.getByText(/no valid projects found/i)
-        ).toBeInTheDocument();
+        expect(screen.getByRole('alert')).toHaveTextContent(/no valid projects found/i);
       });
     });
 
@@ -243,7 +241,7 @@ describe('Resume Page', () => {
       fireEvent.click(screen.getByRole('button', { name: /generate resume/i }));
 
       await waitFor(() => {
-        expect(screen.getByText(/failed to generate resume/i)).toBeInTheDocument();
+        expect(screen.getByRole('alert')).toHaveTextContent(/failed to generate resume/i);
       });
     });
 
@@ -319,6 +317,44 @@ describe('Resume Page', () => {
       });
 
       expect(resumeAPI.generateResume).not.toHaveBeenCalled();
+    });
+
+    it('blocks generate when phone has fewer than 7 digits', async () => {
+      setupDefaultMocks();
+      resumeAPI.getPersonalInfo.mockResolvedValue({
+        personal_info: { ...MOCK_VALID_PERSONAL_INFO, phone: '123456' },
+      });
+
+      renderResume();
+      await screen.findByText('CapstoneApp');
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      fireEvent.click(checkboxes[0]);
+      fireEvent.click(screen.getByRole('button', { name: /generate resume/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/minimum of 7 digits required/i)).toBeInTheDocument();
+      });
+
+      expect(resumeAPI.generateResume).not.toHaveBeenCalled();
+    });
+
+    it('shows error in toast at top when generate fails validation', async () => {
+      setupDefaultMocks();
+      resumeAPI.getPersonalInfo.mockResolvedValue({
+        personal_info: { ...MOCK_VALID_PERSONAL_INFO, name: '' },
+      });
+
+      renderResume();
+      await screen.findByText('CapstoneApp');
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      fireEvent.click(checkboxes[0]);
+      fireEvent.click(screen.getByRole('button', { name: /generate resume/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent(/please fix the personal information errors/i);
+      });
     });
 
     it('blocks generate when name is empty', async () => {

--- a/src/frontend/src/tests/Settings.test.jsx
+++ b/src/frontend/src/tests/Settings.test.jsx
@@ -510,6 +510,32 @@ describe('Settings Page', () => {
       expect(resumeAPI.savePersonalInfo).not.toHaveBeenCalled();
     });
 
+    it('validation blocks save when phone has fewer than 7 digits', async () => {
+      consentAPI.getConsent.mockResolvedValue({ has_consented: false });
+      resumeAPI.getPersonalInfo.mockResolvedValue({
+        personal_info: { name: 'Harjot', email: 'h@h.com', phone: '5551234567' },
+      });
+
+      renderSettings();
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('Harjot')).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Phone Number'), {
+        target: { value: '123456' },
+      });
+
+      const saveBtn = screen.getByRole('button', { name: /update personal info|save personal info/i });
+      fireEvent.click(saveBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/minimum of 7 digits required/i)).toBeInTheDocument();
+      });
+
+      expect(resumeAPI.savePersonalInfo).not.toHaveBeenCalled();
+    });
+
     it('validation blocks save when name is empty', async () => {
       consentAPI.getConsent.mockResolvedValue({ has_consented: false });
       resumeAPI.getPersonalInfo.mockResolvedValue({


### PR DESCRIPTION


## 📝 Description
- added validation for the personal information
- works in both resume page and settings page
- can cancel out to previously saved information

**Closes** #442 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Manual testing
- check that you can only input validated items in the personal information page
- try enter wrong information
- try generate a resume with wrong and correct information.


### Automatic tests
```
 npm run test -- --run src/tests/Settings.test.jsx src/tests/Resume.test.jsx
```

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
do not worry about this errors

<img width="936" height="198" alt="image" src="https://github.com/user-attachments/assets/38cdaae2-88d5-477f-8ae3-e24638edd35f" />
</details>
